### PR TITLE
Period fix

### DIFF
--- a/src/libs/feeds.ts
+++ b/src/libs/feeds.ts
@@ -39,8 +39,11 @@ export async function updateCanvasCache(db: Db, user: string) {
 		// Mongo operators don't work for insertMany so set creation time manually
 		ev.createdAt = creationDate;
 
-		if (typeof ev.description === 'string') {
-			ev.description = ev.description.replace(/\./g, '&period;');
+		// Iterate through all keys and remove any that contain periods
+		for (const key of Object.keys(ev)) {
+			if (key.includes('.')) {
+				delete ev[key];
+			}
 		}
 	}
 

--- a/src/libs/feeds.ts
+++ b/src/libs/feeds.ts
@@ -38,6 +38,10 @@ export async function updateCanvasCache(db: Db, user: string) {
 		ev.user = userDoc!._id;
 		// Mongo operators don't work for insertMany so set creation time manually
 		ev.createdAt = creationDate;
+
+		if (typeof ev.description === 'string') {
+			ev.description = ev.description.replace(/\./g, '&period;');
+		}
 	}
 
 	try {


### PR DESCRIPTION
Found the actual root cause. Seems that the ical parser is messing up somehow and is creating a JSON dict which does something like:
```json
{
    "summary": "blah blah blah",
    "description: Canvas summary assignment with period .": "continue value"
}
```

I'll have to double check, but it may be that when there's a URL in the description, the parser just splits the last colon into the key and value? And thus if there's a period occurring before the URL then it becomes an invalid key.